### PR TITLE
STAR-127 Cleanup SRT implementation and improve thread safety

### DIFF
--- a/SRTNet.h
+++ b/SRTNet.h
@@ -147,7 +147,7 @@ public:
                        std::shared_ptr<NetworkConnection>& ctx, SRTSOCKET socket)> receivedData = nullptr;
 
     ///Callback receiving data no copy
-    std::function<void(const uint8_t* data, size_t size, SRT_MSGCTRL& msgctrl,
+    std::function<void(const uint8_t* data, size_t size, SRT_MSGCTRL& msgCtrl,
                        std::shared_ptr<NetworkConnection>& ctx, SRTSOCKET socket)> receivedDataNoCopy = nullptr;
 
     ///Callback handling disconnecting clients (server and client mode)

--- a/SRTNet.h
+++ b/SRTNet.h
@@ -7,15 +7,8 @@
 // Created by Anders Cedronius on 2019-04-21.
 //
 
-// Prefixes used
-// m class member
-// p pointer (*)
-// r reference (&)
-// h part of header
-// l local scope
 
-#ifndef CPPSRTWRAPPER_SRTNET_H
-#define CPPSRTWRAPPER_SRTNET_H
+#pragma once
 
 #include <iostream>
 #include <functional>
@@ -74,35 +67,35 @@ public:
      *
      * Starts a SRT Server
      *
-     * @param lIp Listen IP
-     * @param lPort Listen Port
-     * @param lReorder number of packets in re-order window
-     * @param lLatency Max re-send window (ms) / also the delay of transmission
-     * @param lOverhead % extra of the BW that will be allowed for re-transmission packets
-     * @param lMtu sets the MTU
-     * @param lPsk Optional Pre Shared Key (AES-128)
-     * @param pCtx optional context used only in the clientConnected callback
+     * @param ip Listen IP
+     * @param port Listen Port
+     * @param reorder number of packets in re-order window
+     * @param latency Max re-send window (ms) / also the delay of transmission
+     * @param overhead % extra of the BW that will be allowed for re-transmission packets
+     * @param mtu sets the MTU
+     * @param psk Optional Pre Shared Key (AES-128)
+     * @param ctx optional context used only in the clientConnected callback
      * @return true if server was able to start
     */
-    bool startServer(const std::string& lIp, uint16_t lPort, int lReorder, int32_t lLatency, int lOverhead, int lMtu,
-                     const std::string& lPsk = "", std::shared_ptr<NetworkConnection> pCtx = {});
+    bool startServer(const std::string& ip, uint16_t port, int reorder, int32_t latency, int overhead, int mtu,
+                     const std::string& psk = "", std::shared_ptr<NetworkConnection> ctx = {});
 
     /**
      *
      * Starts a SRT Client
      *
-     * @param lHost Host IP
-     * @param lPort Host Port
-     * @param lReorder number of packets in re-order window
-     * @param lLatency Max re-send window (ms) / also the delay of transmission
-     * @param lOverhead % extra of the BW that will be allowed for re-transmission packets
-     * @param rpCtx the context used in the receivedData and receivedDataNoCopy callback
-     * @param lMtu sets the MTU
-     * @param lPsk Optional Pre Shared Key (AES-128)
+     * @param host Host IP
+     * @param port Host Port
+     * @param reorder number of packets in re-order window
+     * @param latency Max re-send window (ms) / also the delay of transmission
+     * @param overhead % extra of the BW that will be allowed for re-transmission packets
+     * @param ctx the context used in the receivedData and receivedDataNoCopy callback
+     * @param mtu sets the MTU
+     * @param psk Optional Pre Shared Key (AES-128)
      * @return true if client was able to connect to the server
     */
-    bool startClient(const std::string& lHost, uint16_t lPort, int lReorder, int32_t lLatency, int lOverhead,
-                     std::shared_ptr<NetworkConnection> &rpCtx, int lMtu, const std::string& lPsk = "");
+    bool startClient(const std::string& host, uint16_t port, int reorder, int32_t latency, int overhead,
+                     std::shared_ptr<NetworkConnection>& ctx, int mtu, const std::string& psk = "");
 
     /**
      *
@@ -116,49 +109,49 @@ public:
      *
      * Send data
      *
-     * @param pData pointer to the data
-     * @param lSize size of the data
-     * @param pMsgCtrl pointer to a SRT_MSGCTRL struct.
-     * @param lTargetSystem the target sending the data to (used in server mode only)
+     * @param data pointer to the data
+     * @param size size of the data
+     * @param msgCtrl pointer to a SRT_MSGCTRL struct.
+     * @param targetSystem the target sending the data to (used in server mode only)
      * @return true if sendData was able to send the data to the target.
     */
-    bool sendData(const uint8_t *pData, size_t lSize, SRT_MSGCTRL *pMsgCtrl, SRTSOCKET lTargetSystem = 0);
+    bool sendData(const uint8_t* data, size_t size, SRT_MSGCTRL* msgCtrl, SRTSOCKET targetSystem = 0);
 
     /**
      *
      * Get connection statistics
      *
-     * @param pCurrentStats pointer to the statistics struct
-     * @param lClear Clears the data after reading SRTNetClearStats::yes or no
-     * @param lInstantaneous Get the parameters now SRTNetInstant::yes or filtered values SRTNetInstant::no
-     * @param lTargetSystem The target connection to get statistics about (used in server mode only)
+     * @param currentStats pointer to the statistics struct
+     * @param clear Clears the data after reading SRTNetClearStats::yes or no
+     * @param instantaneous Get the parameters now SRTNetInstant::yes or filtered values SRTNetInstant::no
+     * @param targetSystem The target connection to get statistics about (used in server mode only)
      * @return true if statistics was populated.
     */
-    bool getStatistics(SRT_TRACEBSTATS *pCurrentStats, int lClear, int lInstantaneous, SRTSOCKET lTargetSystem = 0);
+    bool getStatistics(SRT_TRACEBSTATS* currentStats, int clear, int instantaneous, SRTSOCKET targetSystem = 0);
 
     /**
      *
      * Get active clients (A server method)
      *
-     * @param rFunction. pass a function getting the map containing the list of active connections
+     * @param function. pass a function getting the map containing the list of active connections
      * Where the map contains the SRTSocketHandle (SRTSOCKET) and it's associated NetworkConnection you provided.
     */
     void
-    getActiveClients(const std::function<void(std::map<SRTSOCKET, std::shared_ptr<NetworkConnection>> &)> &rFunction);
+    getActiveClients(const std::function<void(std::map<SRTSOCKET, std::shared_ptr<NetworkConnection>>&)>& function);
 
     ///Callback handling connecting clients (only server mode)
-    std::function<std::shared_ptr<NetworkConnection>(struct sockaddr &rSin,
-                                                     SRTSOCKET lNewSocket, std::shared_ptr<NetworkConnection> &rpCtx)> clientConnected = nullptr;
+    std::function<std::shared_ptr<NetworkConnection>(struct sockaddr& sin, SRTSOCKET newSocket,
+                                                    std::shared_ptr<NetworkConnection>& ctx)> clientConnected = nullptr;
     ///Callback receiving data type vector
-    std::function<void(std::unique_ptr<std::vector<uint8_t>> &rData, SRT_MSGCTRL &rMsgCtrl,
-                       std::shared_ptr<NetworkConnection> &rpCtx, SRTSOCKET lSocket)> receivedData = nullptr;
+    std::function<void(std::unique_ptr<std::vector<uint8_t>>& data, SRT_MSGCTRL& msgCtrl,
+                       std::shared_ptr<NetworkConnection>& ctx, SRTSOCKET socket)> receivedData = nullptr;
 
     ///Callback receiving data no copy
-    std::function<void(const uint8_t *pData, size_t lSize, SRT_MSGCTRL &rMsgCtrl,
-                       std::shared_ptr<NetworkConnection> &rCtx, SRTSOCKET lSocket)> receivedDataNoCopy = nullptr;
+    std::function<void(const uint8_t* data, size_t size, SRT_MSGCTRL& msgctrl,
+                       std::shared_ptr<NetworkConnection>& ctx, SRTSOCKET socket)> receivedDataNoCopy = nullptr;
 
     ///Callback handling disconnecting clients (server and client mode)
-    std::function<void(std::shared_ptr<NetworkConnection> &rCtx,
+    std::function<void(std::shared_ptr<NetworkConnection> &ctx,
                                                      SRTSOCKET lSocket)> clientDisconnected = nullptr;
 
     // delete copy and move constructors and assign operators
@@ -185,14 +178,13 @@ private:
     static bool isIPv4(const std::string &str);
     static bool isIPv6(const std::string &str);
 
-    //Server avtive? true == yes
+    //Server active? true == yes
     std::atomic<bool> mServerActive = {false};
-    //Client avtive? true == yes
-    std::atomic<bool> mClientActive;
-    //Server thread active? true == yes
-    std::atomic<bool> mServerListenThreadActive;
-    //Client thread active? true == yes
-    std::atomic<bool> mClientThreadActive;
+    //Client active? true == yes
+    std::atomic<bool> mClientActive = {false};
+
+    std::thread mWorkerThread;
+    std::thread mEventThread;
 
     SRTSOCKET mContext = 0;
     int mPollID = 0;
@@ -203,6 +195,3 @@ private:
     std::shared_ptr<NetworkConnection> mClientContext = nullptr;
     std::shared_ptr<NetworkConnection> mConnectionContext = nullptr;
 };
-
-
-#endif //CPPSRTWRAPPER_SRTNET_H


### PR DESCRIPTION
Fixes the issues mentioned in the ticket and cleans up the naming scheme by removing l and r prefixes.