### PR TITLE
STAR-253 Add get connection context method for SRT clients

### DIFF
--- a/SRTNet.cpp
+++ b/SRTNet.cpp
@@ -393,6 +393,15 @@ void SRTNet::clientWorker() {
     mClientActive = false;
 }
 
+
+std::pair<SRTSOCKET, std::shared_ptr<SRTNet::NetworkConnection>> SRTNet::getConnectedServer() {
+    if (mCurrentMode == Mode::client) {
+        return {mContext, mClientContext};
+    }
+    return {0, nullptr};
+}
+
+
 bool SRTNet::sendData(const uint8_t* data, size_t len, SRT_MSGCTRL* msgCtrl, SRTSOCKET targetSystem) {
     int result;
 

--- a/SRTNet.h
+++ b/SRTNet.h
@@ -139,6 +139,18 @@ public:
     void
     getActiveClients(const std::function<void(std::map<SRTSOCKET, std::shared_ptr<NetworkConnection>>&)>& function);
 
+    /**
+     *
+     * @brief Get the SRT socket and the network connection context object associated with the connected server. This method
+     * only works when in client mode.
+     * @returns The SRT socket and network connection context of the connected server in case this SRTNet is in client
+     * mode and is connected to a SRT server. Returns {0, nullptr} if not in client mode or if in client mode and not
+     * connected yet.
+     *
+    */
+    std::pair<SRTSOCKET, std::shared_ptr<NetworkConnection>> getConnectedServer();
+
+
     ///Callback handling connecting clients (only server mode)
     std::function<std::shared_ptr<NetworkConnection>(struct sockaddr& sin, SRTSOCKET newSocket,
                                                     std::shared_ptr<NetworkConnection>& ctx)> clientConnected = nullptr;


### PR DESCRIPTION
SRT in server mode lets the user associate a context object to the connection which can be retrieved using the getActiveClients method. SRT in client mode also supports associating a context with the connection, but there was no way to get the context outside of the retreive-callback. This PR adds a client mode method for getting the context, similar to getActiveClients for the server mode. 

I think we should consider splitting SRTNet into a SRTClient and a SRTServer class. 