### PR TITLE
STAR-842 Make bind address configurable in client mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,8 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 include(ExternalProject)
 ExternalProject_Add(project_srt
         GIT_REPOSITORY https://github.com/Haivision/srt.git
-        GIT_TAG v1.5.1
+        #  We use the git commit hash because it is faster
+        GIT_TAG 0bc3b03202b3159fc9b085b3ae6d66ec071c25d6 # v1.5.1
         SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/srt
         BINARY_DIR ${CMAKE_CURRENT_SOURCE_DIR}/srt
         CONFIGURE_COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/srt/configure --CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/SRTNet.cpp
+++ b/SRTNet.cpp
@@ -485,6 +485,10 @@ std::pair<SRTSOCKET, std::shared_ptr<SRTNet::NetworkConnection>> SRTNet::getConn
     return {0, nullptr};
 }
 
+SRTSOCKET SRTNet::getBoundSocket() const {
+    return mContext;
+}
+
 SRTNet::Mode SRTNet::getCurrentMode() const {
     std::lock_guard<std::mutex> lock(mNetMtx);
     return mCurrentMode;

--- a/SRTNet.cpp
+++ b/SRTNet.cpp
@@ -8,10 +8,68 @@
 //
 
 #include "SRTNet.h"
+
+#include <optional>
+
 #include "SRTNetInternal.h"
 
+namespace {
+
+/// Wrapper around sockaddr_in
+class SocketAddress {
+public:
+    SocketAddress(const std::string& ip, uint16_t port)
+        : mIP(ip)
+        , mPort(port) {
+    }
+
+    ///
+    /// @return True if this SocketAddress is an IPv4 address
+    bool isIPv4() {
+        sockaddr_in sa = {0};
+        return inet_pton(AF_INET, mIP.c_str(), &sa.sin_addr) != 0;
+    }
+
+    ///
+    /// @return True if this SocketAddress is an IPv6 address
+    bool isIPv6() {
+        sockaddr_in6 sa = {0};
+        return inet_pton(AF_INET6, mIP.c_str(), &sa.sin6_addr) != 0;
+    }
+
+    ///
+    /// @return Get this address as an IPv4 sockaddr_in, nullopt if not a valid IPv4 address
+    [[nodiscard]] std::optional<sockaddr_in> getIPv4() const {
+        sockaddr_in socketAddressV4 = {0};
+        socketAddressV4.sin_family = AF_INET;
+        socketAddressV4.sin_port = htons(mPort);
+        if (inet_pton(AF_INET, mIP.c_str(), &socketAddressV4.sin_addr) != 1) {
+            return std::nullopt;
+        }
+        return socketAddressV4;
+    }
+
+    ///
+    /// @return Get this address as an IPv6 sockaddr_in6, nullopt if not a valid IPv6 address
+    [[nodiscard]] std::optional<sockaddr_in6> getIPv6() const {
+        sockaddr_in6 socketAddressV6 = {0};
+        socketAddressV6.sin6_family = AF_INET6;
+        socketAddressV6.sin6_port = htons(mPort);
+        if (inet_pton(AF_INET6, mIP.c_str(), &socketAddressV6.sin6_addr) != 1) {
+            return std::nullopt;
+        }
+        return socketAddressV6;
+    }
+
+private:
+    std::string mIP;
+    uint16_t mPort;
+};
+
+} // namespace
+
 SRTNet::SRTNet() {
-    SRT_LOGGER(true, LOGG_NOTIFY, "SRTNet constructed")
+    SRT_LOGGER(true, LOGG_NOTIFY, "SRTNet constructed");
 }
 
 SRTNet::~SRTNet() {
@@ -21,10 +79,10 @@ SRTNet::~SRTNet() {
 
 void SRTNet::closeAllClientSockets() {
     std::lock_guard<std::mutex> lock(mClientListMtx);
-    for (auto &client: mClientList) {
+    for (auto& client : mClientList) {
         SRTSOCKET socket = client.first;
         int result = srt_close(socket);
-        if(clientDisconnected) {
+        if (clientDisconnected) {
             clientDisconnected(client.second, socket);
         }
         if (result == SRT_ERROR) {
@@ -34,35 +92,27 @@ void SRTNet::closeAllClientSockets() {
     mClientList.clear();
 }
 
-bool SRTNet::isIPv4(const std::string &str) {
-    struct sockaddr_in sa = {0};
-    return inet_pton(AF_INET, str.c_str(), &sa.sin_addr) != 0;
-}
-
-bool SRTNet::isIPv6(const std::string &str) {
-    struct sockaddr_in6 sa = {0};
-    return inet_pton(AF_INET6, str.c_str(), &sa.sin6_addr) != 0;
-}
-
-bool SRTNet::startServer(const std::string& ip, uint16_t port, int reorder, int32_t latency, int overhead, int mtu,
-                         const std::string& psk, bool singleSender, std::shared_ptr<NetworkConnection> ctx) {
-
-    struct sockaddr_in saV4 = {0};
-    struct sockaddr_in6 saV6 = {0};
-
-    int ipType = AF_INET;
-    if (isIPv4(ip)) {
-        ipType = AF_INET;
-    } else if (isIPv6(ip)) {
-        ipType = AF_INET6;
-    } else {
-        SRT_LOGGER(true, LOGG_ERROR, " " << "Provided IP-Address not valid.");
-    }
-
+bool SRTNet::startServer(const std::string& ip,
+                         uint16_t port,
+                         int reorder,
+                         int32_t latency,
+                         int overhead,
+                         int mtu,
+                         const std::string& psk,
+                         bool singleSender,
+                         std::shared_ptr<NetworkConnection> ctx) {
     std::lock_guard<std::mutex> lock(mNetMtx);
 
+    SocketAddress socketAddress(ip, port);
+    if (!socketAddress.isIPv4() && !socketAddress.isIPv6()) {
+        SRT_LOGGER(true, LOGG_ERROR, "Failed to parse socket address");
+        return false;
+    }
+
     if (mCurrentMode != Mode::unknown) {
-        SRT_LOGGER(true, LOGG_ERROR, " " << "SRTNet mode is already set");
+        SRT_LOGGER(true, LOGG_ERROR,
+                   " "
+                       << "SRTNet mode is already set");
         return false;
     }
 
@@ -71,32 +121,12 @@ bool SRTNet::startServer(const std::string& ip, uint16_t port, int reorder, int3
         return false;
     }
 
-    mConnectionContext = ctx; //retain the optional context
+    mConnectionContext = ctx; // retain the optional context
 
     mContext = srt_create_socket();
     if (mContext == SRT_ERROR) {
         SRT_LOGGER(true, LOGG_FATAL, "srt_socket: " << srt_getlasterror_str());
         return false;
-    }
-
-    if (ipType == AF_INET) {
-        saV4.sin_family = AF_INET;
-        saV4.sin_port = htons(port);
-        if (inet_pton(AF_INET, ip.c_str(), &saV4.sin_addr) != 1) {
-            SRT_LOGGER(true, LOGG_FATAL, "inet_pton failed ");
-            srt_close(mContext);
-            return false;
-        }
-    }
-
-    if (ipType == AF_INET6) {
-        saV6.sin6_family = AF_INET6;
-        saV6.sin6_port = htons(port);
-        if (inet_pton(AF_INET6, ip.c_str(), &saV6.sin6_addr) != 1) {
-            SRT_LOGGER(true, LOGG_FATAL, "inet_pton failed ");
-            srt_close(mContext);
-            return false;
-        }
     }
 
     int32_t yes = 1;
@@ -145,8 +175,9 @@ bool SRTNet::startServer(const std::string& ip, uint16_t port, int reorder, int3
         }
     }
 
-    if (ipType == AF_INET) {
-        result = srt_bind(mContext, reinterpret_cast<sockaddr*>(&saV4), sizeof(saV4));
+    std::optional<sockaddr_in> ipv4Address = socketAddress.getIPv4();
+    if (ipv4Address.has_value()) {
+        result = srt_bind(mContext, reinterpret_cast<sockaddr*>(&ipv4Address.value()), sizeof(ipv4Address.value()));
         if (result == SRT_ERROR) {
             SRT_LOGGER(true, LOGG_FATAL, "srt_bind: " << srt_getlasterror_str());
             srt_close(mContext);
@@ -154,8 +185,9 @@ bool SRTNet::startServer(const std::string& ip, uint16_t port, int reorder, int3
         }
     }
 
-    if (ipType == AF_INET6) {
-        result = srt_bind(mContext, reinterpret_cast<sockaddr*>(&saV6), sizeof(saV6));
+    std::optional<sockaddr_in6> ipv6Address = socketAddress.getIPv6();
+    if (ipv6Address.has_value()) {
+        result = srt_bind(mContext, reinterpret_cast<sockaddr*>(&ipv6Address.value()), sizeof(ipv6Address.value()));
         if (result == SRT_ERROR) {
             SRT_LOGGER(true, LOGG_FATAL, "srt_bind: " << srt_getlasterror_str());
             srt_close(mContext);
@@ -174,7 +206,6 @@ bool SRTNet::startServer(const std::string& ip, uint16_t port, int reorder, int3
     mWorkerThread = std::thread(&SRTNet::waitForSRTClient, this, singleSender);
     return true;
 }
-
 
 void SRTNet::serverEventHandler() {
     SRT_EPOLL_EVENT ready[MAX_WORKERS];
@@ -202,7 +233,7 @@ void SRTNet::serverEventHandler() {
                     mClientList.erase(iterator->first);
                     srt_epoll_remove_usock(mPollID, thisSocket);
                     srt_close(thisSocket);
-                    if(clientDisconnected) {
+                    if (clientDisconnected) {
                         clientDisconnected(ctx, thisSocket);
                     }
                 } else if (result > 0 && receivedData) {
@@ -215,7 +246,6 @@ void SRTNet::serverEventHandler() {
         } else if (ret == -1) {
             SRT_LOGGER(true, LOGG_ERROR, "epoll error: " << srt_getlasterror_str());
         }
-
     }
     SRT_LOGGER(true, LOGG_NOTIFY, "serverEventHandler exit");
 
@@ -263,24 +293,40 @@ void SRTNet::waitForSRTClient(bool singleSender) {
     }
 }
 
-void SRTNet::getActiveClients(const std::function<void(std::map<SRTSOCKET, std::shared_ptr<NetworkConnection>> &)>& function) {
+void SRTNet::getActiveClients(
+    const std::function<void(std::map<SRTSOCKET, std::shared_ptr<NetworkConnection>>&)>& function) {
     std::lock_guard<std::mutex> lock(mClientListMtx);
     function(mClientList);
 }
 
-//Host can provide a IP or name meaning any IPv4 or IPv6 address or name type www.google.com
-//There is no IP-Version preference if a name is given. the first IP-version found will be used
 bool SRTNet::startClient(const std::string& host,
                          uint16_t port,
                          int reorder,
                          int32_t latency,
                          int overhead,
-                         std::shared_ptr<NetworkConnection> &ctx,
+                         std::shared_ptr<NetworkConnection>& ctx,
+                         int mtu,
+                         const std::string& psk) {
+    return startClient(host, port, "0.0.0.0", 0, reorder, latency, overhead, ctx, mtu, psk);
+}
+
+// Host can provide a IP or name meaning any IPv4 or IPv6 address or name type www.google.com
+// There is no IP-Version preference if a name is given. the first IP-version found will be used
+bool SRTNet::startClient(const std::string& host,
+                         uint16_t port,
+                         const std::string& localHost,
+                         uint16_t localPort,
+                         int reorder,
+                         int32_t latency,
+                         int overhead,
+                         std::shared_ptr<NetworkConnection>& ctx,
                          int mtu,
                          const std::string& psk) {
     std::lock_guard<std::mutex> lock(mNetMtx);
     if (mCurrentMode != Mode::unknown) {
-        SRT_LOGGER(true, LOGG_ERROR, " " << "SRTNet mode is already set");
+        SRT_LOGGER(true, LOGG_ERROR,
+                   " "
+                       << "SRTNet mode is already set");
         return false;
     }
 
@@ -341,7 +387,38 @@ bool SRTNet::startClient(const std::string& host,
         }
     }
 
-    //get all addresses for connection
+    // Set local interface to bind to
+    SocketAddress localSocketAddress(localHost, localPort);
+
+    std::optional<sockaddr_in> localIPv4Address = localSocketAddress.getIPv4();
+    if (localIPv4Address.has_value()) {
+        result = srt_bind(mContext, reinterpret_cast<sockaddr*>(&localIPv4Address.value()),
+                          sizeof(localIPv4Address.value()));
+        if (result == SRT_ERROR) {
+            SRT_LOGGER(true, LOGG_FATAL, "srt_bind: " << srt_getlasterror_str());
+            srt_close(mContext);
+            return false;
+        }
+    }
+
+    std::optional<sockaddr_in6> localIPv6Address = localSocketAddress.getIPv6();
+    if (localIPv6Address.has_value()) {
+        result = srt_bind(mContext, reinterpret_cast<sockaddr*>(&localIPv6Address.value()),
+                          sizeof(localIPv6Address.value()));
+        if (result == SRT_ERROR) {
+            SRT_LOGGER(true, LOGG_FATAL, "srt_bind: " << srt_getlasterror_str());
+            srt_close(mContext);
+            return false;
+        }
+    }
+
+    if (!localIPv4Address.has_value() && !localIPv6Address.has_value()) {
+        SRT_LOGGER(true, LOGG_FATAL, "Failed to parse local socket address");
+        srt_close(mContext);
+        return false;
+    }
+
+    // Get all remote addresses for connection
     struct addrinfo hints = {0};
     struct addrinfo* svr;
     struct addrinfo* hld;
@@ -401,14 +478,12 @@ void SRTNet::clientWorker() {
     mClientActive = false;
 }
 
-
 std::pair<SRTSOCKET, std::shared_ptr<SRTNet::NetworkConnection>> SRTNet::getConnectedServer() {
     if (mCurrentMode == Mode::client) {
         return {mContext, mClientContext};
     }
     return {0, nullptr};
 }
-
 
 SRTNet::Mode SRTNet::getCurrentMode() const {
     std::lock_guard<std::mutex> lock(mNetMtx);
@@ -419,9 +494,9 @@ bool SRTNet::sendData(const uint8_t* data, size_t len, SRT_MSGCTRL* msgCtrl, SRT
     int result;
 
     if (mCurrentMode == Mode::client && mContext && mClientActive) {
-        result = srt_sendmsg2(mContext, reinterpret_cast<const char *>(data), len, msgCtrl);
+        result = srt_sendmsg2(mContext, reinterpret_cast<const char*>(data), len, msgCtrl);
     } else if (mCurrentMode == Mode::server && targetSystem && mServerActive) {
-        result = srt_sendmsg2(targetSystem, reinterpret_cast<const char *>(data), len, msgCtrl);
+        result = srt_sendmsg2(targetSystem, reinterpret_cast<const char*>(data), len, msgCtrl);
     } else {
         SRT_LOGGER(true, LOGG_WARN, "Can't send data, the client is not active.");
         return false;

--- a/SRTNet.cpp
+++ b/SRTNet.cpp
@@ -26,14 +26,14 @@ public:
     ///
     /// @return True if this SocketAddress is an IPv4 address
     bool isIPv4() {
-        sockaddr_in sa = {0};
+        sockaddr_in sa{};
         return inet_pton(AF_INET, mIP.c_str(), &sa.sin_addr) != 0;
     }
 
     ///
     /// @return True if this SocketAddress is an IPv6 address
     bool isIPv6() {
-        sockaddr_in6 sa = {0};
+        sockaddr_in6 sa{};
         return inet_pton(AF_INET6, mIP.c_str(), &sa.sin6_addr) != 0;
     }
 

--- a/SRTNet.h
+++ b/SRTNet.h
@@ -195,6 +195,14 @@ public:
 
     /**
      *
+     * @brief Get the underlying, bound SRT socket. Works both in client and server mode.
+     * @returns The bound socket in case there is one, otherwise 0.
+     *
+     */
+    SRTSOCKET getBoundSocket() const;
+
+    /**
+     *
      * @brief Get the current operating mode.
      * @returns The operating mode.
      *

--- a/SRTNet.h
+++ b/SRTNet.h
@@ -7,48 +7,42 @@
 // Created by Anders Cedronius on 2019-04-21.
 //
 
-
 #pragma once
 
-#include <iostream>
-#include <functional>
+#include <any>
 #include <atomic>
-#include <thread>
-#include <vector>
-#include <utility>
 #include <cstdlib>
+#include <functional>
+#include <iostream>
 #include <map>
 #include <memory>
 #include <mutex>
-#include <any>
+#include <thread>
+#include <utility>
+#include <vector>
+
 #include "srt/srtcore/srt.h"
 
 #ifdef WIN32
 #include <Winsock2.h>
 #define _WINSOCKAPI_
-#include <ws2tcpip.h>
 #include <io.h>
-#pragma comment( lib, "ws2_32.lib")
+#include <ws2tcpip.h>
+#pragma comment(lib, "ws2_32.lib")
 #else
 
 #include <arpa/inet.h>
 
 #endif
 
-#define MAX_WORKERS 20 //Max number of connections to deal with each epoll
+#define MAX_WORKERS 20 // Max number of connections to deal with each epoll
 
 namespace SRTNetClearStats {
-    enum SRTNetClearStats : int {
-        no,
-        yes
-    };
+enum SRTNetClearStats : int { no, yes };
 }
 
 namespace SRTNetInstant {
-    enum SRTNetInstant : int {
-        no,
-        yes
-    };
+enum SRTNetInstant : int { no, yes };
 }
 
 class SRTNet {
@@ -60,7 +54,7 @@ public:
         client
     };
 
-    //Fill this class with all information you need for the duration of the connection both client and server
+    // Fill this class with all information you need for the duration of the connection both client and server
     class NetworkConnection {
     public:
         std::any mObject;
@@ -72,28 +66,36 @@ public:
 
     /**
      *
-     * Starts a SRT Server
+     * Starts an SRT Server
      *
-     * @param ip Listen IP
-     * @param port Listen Port
+     * @param localIP Listen IP
+     * @param localPort Listen Port
      * @param reorder number of packets in re-order window
      * @param latency Max re-send window (ms) / also the delay of transmission
      * @param overhead % extra of the BW that will be allowed for re-transmission packets
      * @param mtu sets the MTU
      * @param psk Optional Pre Shared Key (AES-128)
-     * @param singleSender set to true to accept just one sender to connect to the server, otherwise the server will keep waiting and accepting more incoming sender connections
+     * @param singleSender set to true to accept just one sender to connect to the server, otherwise the server will
+     * keep waiting and accepting more incoming sender connections
      * @param ctx optional context used only in the clientConnected callback
      * @return true if server was able to start
-    */
-    bool startServer(const std::string& ip, uint16_t port, int reorder, int32_t latency, int overhead, int mtu,
-                     const std::string& psk = "", bool singleSender = false, std::shared_ptr<NetworkConnection> ctx = {});
+     */
+    bool startServer(const std::string& localIP,
+                     uint16_t localPort,
+                     int reorder,
+                     int32_t latency,
+                     int overhead,
+                     int mtu,
+                     const std::string& psk = "",
+                     bool singleSender = false,
+                     std::shared_ptr<NetworkConnection> ctx = {});
 
     /**
      *
-     * Starts a SRT Client
+     * Starts an SRT Client
      *
-     * @param host Host IP
-     * @param port Host Port
+     * @param host Remote host IP or hostname
+     * @param port Remote host Port
      * @param reorder number of packets in re-order window
      * @param latency Max re-send window (ms) / also the delay of transmission
      * @param overhead % extra of the BW that will be allowed for re-transmission packets
@@ -101,16 +103,49 @@ public:
      * @param mtu sets the MTU
      * @param psk Optional Pre Shared Key (AES-128)
      * @return true if client was able to connect to the server
-    */
-    bool startClient(const std::string& host, uint16_t port, int reorder, int32_t latency, int overhead,
-                     std::shared_ptr<NetworkConnection>& ctx, int mtu, const std::string& psk = "");
+     */
+    bool startClient(const std::string& host,
+                     uint16_t port,
+                     int reorder,
+                     int32_t latency,
+                     int overhead,
+                     std::shared_ptr<NetworkConnection>& ctx,
+                     int mtu,
+                     const std::string& psk = "");
+
+    /**
+     *
+     * Starts an SRT Client with a specified local address to bind to
+     *
+     * @param host Remote host IP or hostname to connect to
+     * @param port Remote host port to connect to
+     * @param localHost Local host IP to bind to
+     * @param localPort Local port to bind to, use 0 to automatically pick an unused port
+     * @param reorder number of packets in re-order window
+     * @param latency Max re-send window (ms) / also the delay of transmission
+     * @param overhead % extra of the BW that will be allowed for re-transmission packets
+     * @param ctx the context used in the receivedData and receivedDataNoCopy callback
+     * @param mtu sets the MTU
+     * @param psk Optional Pre Shared Key (AES-128)
+     * @return true if client was able to connect to the server
+     */
+    bool startClient(const std::string& host,
+                     uint16_t port,
+                     const std::string& localHost,
+                     uint16_t localPort,
+                     int reorder,
+                     int32_t latency,
+                     int overhead,
+                     std::shared_ptr<NetworkConnection>& ctx,
+                     int mtu,
+                     const std::string& psk = "");
 
     /**
      *
      * Stops the service
      *
      * @return true if the service stopped successfully.
-    */
+     */
     bool stop();
 
     /**
@@ -122,7 +157,7 @@ public:
      * @param msgCtrl pointer to a SRT_MSGCTRL struct.
      * @param targetSystem the target sending the data to (used in server mode only)
      * @return true if sendData was able to send the data to the target.
-    */
+     */
     bool sendData(const uint8_t* data, size_t size, SRT_MSGCTRL* msgCtrl, SRTSOCKET targetSystem = 0);
 
     /**
@@ -134,7 +169,7 @@ public:
      * @param instantaneous Get the parameters now SRTNetInstant::yes or filtered values SRTNetInstant::no
      * @param targetSystem The target connection to get statistics about (used in server mode only)
      * @return true if statistics was populated.
-    */
+     */
     bool getStatistics(SRT_TRACEBSTATS* currentStats, int clear, int instantaneous, SRTSOCKET targetSystem = 0);
 
     /**
@@ -143,19 +178,19 @@ public:
      *
      * @param function. pass a function getting the map containing the list of active connections
      * Where the map contains the SRTSocketHandle (SRTSOCKET) and it's associated NetworkConnection you provided.
-    */
+     */
     void
     getActiveClients(const std::function<void(std::map<SRTSOCKET, std::shared_ptr<NetworkConnection>>&)>& function);
 
     /**
      *
-     * @brief Get the SRT socket and the network connection context object associated with the connected server. This method
-     * only works when in client mode.
+     * @brief Get the SRT socket and the network connection context object associated with the connected server. This
+     * method only works when in client mode.
      * @returns The SRT socket and network connection context of the connected server in case this SRTNet is in client
      * mode and is connected to a SRT server. Returns {0, nullptr} if not in client mode or if in client mode and not
      * connected yet.
      *
-    */
+     */
     std::pair<SRTSOCKET, std::shared_ptr<NetworkConnection>> getConnectedServer();
 
     /**
@@ -166,43 +201,49 @@ public:
     */
     Mode getCurrentMode() const;
 
+    /// Callback handling connecting clients (only server mode)
+    std::function<std::shared_ptr<NetworkConnection>(struct sockaddr& sin,
+                                                     SRTSOCKET newSocket,
+                                                     std::shared_ptr<NetworkConnection>& ctx)>
+        clientConnected = nullptr;
+    /// Callback receiving data type vector
+    std::function<void(std::unique_ptr<std::vector<uint8_t>>& data,
+                       SRT_MSGCTRL& msgCtrl,
+                       std::shared_ptr<NetworkConnection>& ctx,
+                       SRTSOCKET socket)>
+        receivedData = nullptr;
 
-    ///Callback handling connecting clients (only server mode)
-    std::function<std::shared_ptr<NetworkConnection>(struct sockaddr& sin, SRTSOCKET newSocket,
-                                                    std::shared_ptr<NetworkConnection>& ctx)> clientConnected = nullptr;
-    ///Callback receiving data type vector
-    std::function<void(std::unique_ptr<std::vector<uint8_t>>& data, SRT_MSGCTRL& msgCtrl,
-                       std::shared_ptr<NetworkConnection>& ctx, SRTSOCKET socket)> receivedData = nullptr;
+    /// Callback receiving data no copy
+    std::function<void(const uint8_t* data,
+                       size_t size,
+                       SRT_MSGCTRL& msgCtrl,
+                       std::shared_ptr<NetworkConnection>& ctx,
+                       SRTSOCKET socket)>
+        receivedDataNoCopy = nullptr;
 
-    ///Callback receiving data no copy
-    std::function<void(const uint8_t* data, size_t size, SRT_MSGCTRL& msgCtrl,
-                       std::shared_ptr<NetworkConnection>& ctx, SRTSOCKET socket)> receivedDataNoCopy = nullptr;
-
-    ///Callback handling disconnecting clients (server and client mode)
-    std::function<void(std::shared_ptr<NetworkConnection> &ctx,
-                                                     SRTSOCKET lSocket)> clientDisconnected = nullptr;
+    /// Callback handling disconnecting clients (server and client mode)
+    std::function<void(std::shared_ptr<NetworkConnection>& ctx, SRTSOCKET lSocket)> clientDisconnected = nullptr;
 
     // delete copy and move constructors and assign operators
-    SRTNet(SRTNet const &) = delete;             // Copy construct
-    SRTNet(SRTNet &&) = delete;                  // Move construct
-    SRTNet &operator=(SRTNet const &) = delete;  // Copy assign
-    SRTNet &operator=(SRTNet &&) = delete;      // Move assign
-
+    SRTNet(SRTNet const&) = delete;            // Copy construct
+    SRTNet(SRTNet&&) = delete;                 // Move construct
+    SRTNet& operator=(SRTNet const&) = delete; // Copy assign
+    SRTNet& operator=(SRTNet&&) = delete;      // Move assign
 
 private:
-
-    //Internal variables and methods
+    // Internal variables and methods
 
     void waitForSRTClient(bool singleSender);
-    void serverEventHandler();
-    void clientWorker();
-    void closeAllClientSockets();
-    static bool isIPv4(const std::string &str);
-    static bool isIPv6(const std::string &str);
 
-    //Server active? true == yes
+    void serverEventHandler();
+
+    void clientWorker();
+
+    void closeAllClientSockets();
+
+    // Server active? true == yes
     std::atomic<bool> mServerActive = {false};
-    //Client active? true == yes
+    // Client active? true == yes
     std::atomic<bool> mClientActive = {false};
 
     std::thread mWorkerThread;

--- a/test/TestSrt.cpp
+++ b/test/TestSrt.cpp
@@ -515,16 +515,15 @@ TEST(TestSrt, AutomaticPortSelection) {
         return connectionCtx;
     };
 
-    ASSERT_TRUE(server.startServer("0.0.0.0", 0, 16, 1000, 100, SRT_LIVE_MAX_PLSIZE, kValidPsk, false, serverCtx));
+    const uint16_t kAnyPort = 0;
+
+    ASSERT_TRUE(server.startServer("0.0.0.0", kAnyPort, 16, 1000, 100, SRT_LIVE_MAX_PLSIZE, kValidPsk, false, serverCtx));
 
     std::pair<std::string, uint16_t> serverIPAndPort = getBindIpAndPortFromSRTSocket(server.getBoundSocket());
     EXPECT_EQ(serverIPAndPort.first, "0.0.0.0");
     EXPECT_GT(serverIPAndPort.second, 1024); // We expect it won't pick a privileged port
 
-    // TODO remove me
-    std::cout << "Server selected port " << serverIPAndPort.second << std::endl;
-
-    ASSERT_TRUE(client.startClient("127.0.0.1", serverIPAndPort.second, "0.0.0.0", 0, 16, 1000, 100, clientCtx,
+    ASSERT_TRUE(client.startClient("127.0.0.1", serverIPAndPort.second, "0.0.0.0", kAnyPort, 16, 1000, 100, clientCtx,
                                    SRT_LIVE_MAX_PLSIZE, kValidPsk));
 
     // check for client connecting
@@ -538,9 +537,6 @@ TEST(TestSrt, AutomaticPortSelection) {
     EXPECT_EQ(clientIPAndPort.first, "127.0.0.1");
     EXPECT_GT(clientIPAndPort.second, 1024); // We expect it won't pick a privileged port
     EXPECT_NE(clientIPAndPort.second, serverIPAndPort.second);
-
-    // TODO remove me
-    std::cout << "Client selected port " << clientIPAndPort.second << std::endl;
 
     size_t nClients = 0;
     server.getActiveClients([&](std::map<SRTSOCKET, std::shared_ptr<SRTNet::NetworkConnection>>& activeClients) {

--- a/test/TestSrt.cpp
+++ b/test/TestSrt.cpp
@@ -10,6 +10,52 @@ std::string kInvalidPsk = "Th1$_is_4_F4k3_P$k";
 
 size_t kMaxMessageSize = SRT_LIVE_MAX_PLSIZE;
 
+namespace {
+///
+/// @brief Get the bind IP address and port of an SRT socket
+/// @param socket The SRT socket to get the bind IP and Port from
+/// @return The bind IP address and port of the SRT socket
+std::pair<std::string, uint16_t> getBindIpAndPortFromSRTSocket(SRTSOCKET socket) {
+    sockaddr_storage address{};
+    int32_t addressSize = sizeof(decltype(address));
+    EXPECT_EQ(srt_getsockname(socket, reinterpret_cast<sockaddr*>(&address), &addressSize), 0);
+    if (address.ss_family == AF_INET) {
+        const sockaddr_in* socketAddressV4 = reinterpret_cast<const sockaddr_in*>(&address);
+        char ipv4Address[INET_ADDRSTRLEN];
+        EXPECT_NE(inet_ntop(AF_INET, &(socketAddressV4->sin_addr), ipv4Address, INET_ADDRSTRLEN), nullptr);
+        return {ipv4Address, ntohs(socketAddressV4->sin_port)};
+    } else if (address.ss_family == AF_INET6) {
+        const sockaddr_in6* socketAddressV6 = reinterpret_cast<const sockaddr_in6*>(&address);
+        char ipv6Address[INET6_ADDRSTRLEN];
+        EXPECT_NE(inet_ntop(AF_INET, &(socketAddressV6->sin6_addr), ipv6Address, INET6_ADDRSTRLEN), nullptr);
+        return {ipv6Address, ntohs(socketAddressV6->sin6_port)};
+    }
+    return {"Unsupported", 0};
+}
+
+///
+/// @brief Get the remote peer IP address and port of an SRT socket
+/// @param socket The SRT socket to get the peer IP and Port from
+/// @return The peer IP address and port of the SRT socket
+std::pair<std::string, uint16_t> getPeerIpAndPortFromSRTSocket(SRTSOCKET socket) {
+    sockaddr_storage address{};
+    int32_t addressSize = sizeof(decltype(address));
+    EXPECT_EQ(srt_getpeername(socket, reinterpret_cast<sockaddr*>(&address), &addressSize), 0);
+    if (address.ss_family == AF_INET) {
+        const sockaddr_in* socketAddressV4 = reinterpret_cast<const sockaddr_in*>(&address);
+        char ipv4Address[INET_ADDRSTRLEN];
+        EXPECT_NE(inet_ntop(AF_INET, &(socketAddressV4->sin_addr), ipv4Address, INET_ADDRSTRLEN), nullptr);
+        return {ipv4Address, ntohs(socketAddressV4->sin_port)};
+    } else if (address.ss_family == AF_INET6) {
+        const sockaddr_in6* socketAddressV6 = reinterpret_cast<const sockaddr_in6*>(&address);
+        char ipv6Address[INET6_ADDRSTRLEN];
+        EXPECT_NE(inet_ntop(AF_INET, &(socketAddressV6->sin6_addr), ipv6Address, INET6_ADDRSTRLEN), nullptr);
+        return {ipv6Address, ntohs(socketAddressV6->sin6_port)};
+    }
+    return {"Unsupported", 0};
+}
+} // namespace
+
 TEST(TestSrt, StartStop) {
     SRTNet server;
     SRTNet client;
@@ -407,7 +453,7 @@ TEST(TestSrt, BindAddressForCaller) {
         return connectionCtx;
     };
 
-    ASSERT_TRUE(server.startServer("127.0.0.1", 8010, 16, 1000, 100, SRT_LIVE_MAX_PLSIZE, kValidPsk, true, serverCtx));
+    ASSERT_TRUE(server.startServer("127.0.0.1", 8010, 16, 1000, 100, SRT_LIVE_MAX_PLSIZE, kValidPsk, false, serverCtx));
     ASSERT_TRUE(client.startClient("127.0.0.1", 8010, "0.0.0.0", 8011, 16, 1000, 100, clientCtx, SRT_LIVE_MAX_PLSIZE,
                                    kValidPsk));
 
@@ -422,19 +468,93 @@ TEST(TestSrt, BindAddressForCaller) {
     server.getActiveClients([&](std::map<SRTSOCKET, std::shared_ptr<SRTNet::NetworkConnection>>& activeClients) {
         nClients = activeClients.size();
         for (const auto& socketNetworkConnectionPair : activeClients) {
-            sockaddr_in6 peerAddress{};
-            int32_t peerAddressSize = sizeof(decltype(peerAddress));
-            ASSERT_EQ(srt_getpeername(socketNetworkConnectionPair.first, reinterpret_cast<sockaddr*>(&peerAddress),
-                                      &peerAddressSize),
-                      0);
-            const sockaddr* socketAddress = reinterpret_cast<const sockaddr*>(&peerAddress);
-            ASSERT_EQ(socketAddress->sa_family, AF_INET);
-            const sockaddr_in* socketAddressV4 = reinterpret_cast<const sockaddr_in*>(socketAddress);
-            char addressIPv4[INET_ADDRSTRLEN];
-            inet_ntop(AF_INET, &socketAddressV4->sin_addr, addressIPv4, INET_ADDRSTRLEN);
-            std::string ipv4 = std::string(addressIPv4);
-            EXPECT_EQ(ipv4, "127.0.0.1");
-            EXPECT_EQ(ntohs(socketAddressV4->sin_port), 8011);
+            std::pair<std::string, uint16_t> peerIPAndPort =
+                getPeerIpAndPortFromSRTSocket(socketNetworkConnectionPair.first);
+            EXPECT_EQ(peerIPAndPort.first, "127.0.0.1");
+            EXPECT_EQ(peerIPAndPort.second, 8011);
+
+            std::pair<std::string, uint16_t> ipAndPort =
+                getBindIpAndPortFromSRTSocket(socketNetworkConnectionPair.first);
+            EXPECT_EQ(ipAndPort.first, "127.0.0.1");
+            EXPECT_EQ(ipAndPort.second, 8010);
+        }
+    });
+    EXPECT_EQ(nClients, 1);
+
+    std::pair<std::string, uint16_t> serverIPAndPort = getBindIpAndPortFromSRTSocket(server.getBoundSocket());
+    EXPECT_EQ(serverIPAndPort.first, "127.0.0.1");
+    EXPECT_EQ(serverIPAndPort.second, 8010);
+
+    std::pair<std::string, uint16_t> clientIPAndPort = getBindIpAndPortFromSRTSocket(client.getBoundSocket());
+    EXPECT_EQ(clientIPAndPort.first, "127.0.0.1");
+    EXPECT_EQ(clientIPAndPort.second, 8011);
+}
+
+TEST(TestSrt, AutomaticPortSelection) {
+    SRTNet server;
+    SRTNet client;
+
+    auto serverCtx = std::make_shared<SRTNet::NetworkConnection>();
+    auto clientCtx = std::make_shared<SRTNet::NetworkConnection>();
+    clientCtx->mObject = 42;
+
+    std::condition_variable connectedCondition;
+    std::mutex connectedMutex;
+    bool connected = false;
+
+    // notice when client connects to server
+    server.clientConnected = [&](struct sockaddr& sin, SRTSOCKET newSocket,
+                                 std::shared_ptr<SRTNet::NetworkConnection>& ctx) {
+        {
+            std::lock_guard<std::mutex> lock(connectedMutex);
+            connected = true;
+        }
+        connectedCondition.notify_one();
+        auto connectionCtx = std::make_shared<SRTNet::NetworkConnection>();
+        connectionCtx->mObject = 1111;
+        return connectionCtx;
+    };
+
+    ASSERT_TRUE(server.startServer("0.0.0.0", 0, 16, 1000, 100, SRT_LIVE_MAX_PLSIZE, kValidPsk, false, serverCtx));
+
+    std::pair<std::string, uint16_t> serverIPAndPort = getBindIpAndPortFromSRTSocket(server.getBoundSocket());
+    EXPECT_EQ(serverIPAndPort.first, "0.0.0.0");
+    EXPECT_GT(serverIPAndPort.second, 1024); // We expect it won't pick a privileged port
+
+    // TODO remove me
+    std::cout << "Server selected port " << serverIPAndPort.second << std::endl;
+
+    ASSERT_TRUE(client.startClient("127.0.0.1", serverIPAndPort.second, "0.0.0.0", 0, 16, 1000, 100, clientCtx,
+                                   SRT_LIVE_MAX_PLSIZE, kValidPsk));
+
+    // check for client connecting
+    {
+        std::unique_lock<std::mutex> lock(connectedMutex);
+        bool successfulWait = connectedCondition.wait_for(lock, std::chrono::seconds(2), [&]() { return connected; });
+        ASSERT_TRUE(successfulWait) << "Timeout waiting for client to connect";
+    }
+
+    std::pair<std::string, uint16_t> clientIPAndPort = getBindIpAndPortFromSRTSocket(client.getBoundSocket());
+    EXPECT_EQ(clientIPAndPort.first, "127.0.0.1");
+    EXPECT_GT(clientIPAndPort.second, 1024); // We expect it won't pick a privileged port
+    EXPECT_NE(clientIPAndPort.second, serverIPAndPort.second);
+
+    // TODO remove me
+    std::cout << "Client selected port " << clientIPAndPort.second << std::endl;
+
+    size_t nClients = 0;
+    server.getActiveClients([&](std::map<SRTSOCKET, std::shared_ptr<SRTNet::NetworkConnection>>& activeClients) {
+        nClients = activeClients.size();
+        for (const auto& socketNetworkConnectionPair : activeClients) {
+            std::pair<std::string, uint16_t> peerIPAndPort =
+                getPeerIpAndPortFromSRTSocket(socketNetworkConnectionPair.first);
+            EXPECT_EQ(peerIPAndPort.first, "127.0.0.1");
+            EXPECT_EQ(peerIPAndPort.second, clientIPAndPort.second);
+
+            std::pair<std::string, uint16_t> ipAndPort =
+                getBindIpAndPortFromSRTSocket(socketNetworkConnectionPair.first);
+            EXPECT_EQ(ipAndPort.first, "127.0.0.1");
+            EXPECT_EQ(ipAndPort.second, serverIPAndPort.second);
         }
     });
     EXPECT_EQ(nClients, 1);


### PR DESCRIPTION
Make it possible to specify the bind address when using client/caller mode of SRT. It is possible to both set just the IP and let the API pick a random, unused port number by providing 0 as the port number, or to explicitly pick both address and port.

Also refactored a bit by encapsulating the Linux socket API's SocketAddress or sockaddr_in struct. Ran clang-format on the code as well.