### PR TITLE
STAR-896: If last client disconnected, break, and stop the server

### DIFF
--- a/SRTNet.cpp
+++ b/SRTNet.cpp
@@ -217,10 +217,7 @@ bool SRTNet::startServer(const std::string& ip,
 void SRTNet::serverEventHandler() {
     SRT_EPOLL_EVENT ready[MAX_WORKERS];
     while (mServerActive) {
-        int ret = srt_epoll_uwait(mPollID, &ready[0], 5, 1000);
-        if (ret == MAX_WORKERS + 1) {
-            ret--;
-        }
+        int ret = srt_epoll_uwait(mPollID, &ready[0], MAX_WORKERS, 1000);
 
         if (ret > 0) {
             for (size_t i = 0; i < ret; i++) {
@@ -249,6 +246,9 @@ void SRTNet::serverEventHandler() {
                 } else if (result > 0 && receivedDataNoCopy) {
                     receivedDataNoCopy(msg, result, thisMSGCTRL, iterator->second, thisSocket);
                 }
+            }
+            if (mClientList.empty()) {
+                break;
             }
         } else if (ret == -1) {
             SRT_LOGGER(true, LOGG_ERROR, "epoll error: " << srt_getlasterror_str());

--- a/SRTNet.h
+++ b/SRTNet.h
@@ -35,7 +35,7 @@
 
 #endif
 
-#define MAX_WORKERS 20 // Max number of connections to deal with each epoll
+#define MAX_WORKERS 5 // Max number of connections to deal with each epoll
 
 namespace SRTNetClearStats {
 enum SRTNetClearStats : int { no, yes };


### PR DESCRIPTION
This avoids another poll of sockets which times out after 1 second.