### PR TITLE
STAR-951: Change caller mode to do automatic re-connect attempts

### DIFF
--- a/SRTNet.cpp
+++ b/SRTNet.cpp
@@ -345,6 +345,63 @@ bool SRTNet::startClient(const std::string& host,
 
     mClientContext = ctx;
 
+    mCallerLocalHost = localHost;
+    mCallerLocalPort = localPort;
+    mCallerReorder = reorder;
+    mCallerLatency = latency;
+    mCallerOverhead = overhead;
+    mCallerMtu = mtu;
+    mCallerPeerIdleTimeout = peerIdleTimeout;
+    mCallerPsk = psk;
+
+    if (!createClientSocket()) {
+        SRT_LOGGER(true, LOGG_ERROR, "Failed to create caller socket");
+        return false;
+
+    }
+    mCallerHost = host;
+    mCallerPort = port;
+
+    // Get all remote addresses for connection
+    struct addrinfo hints = {0};
+    struct addrinfo* svr;
+    struct addrinfo* hld;
+    hints.ai_socktype = SOCK_DGRAM;
+    hints.ai_protocol = IPPROTO_UDP;
+    hints.ai_family = AF_UNSPEC;
+    std::stringstream portAsString;
+    portAsString << port;
+    int result = getaddrinfo(host.c_str(), portAsString.str().c_str(), &hints, &svr);
+    if (result) {
+        SRT_LOGGER(true, LOGG_FATAL,
+                   "Failed getting the IP target for > " << host << ":" << port << " Errno: " << result);
+        return false;
+    }
+
+    
+    SRT_LOGGER(true, LOGG_ERROR, "SRT connect");
+    for (hld = svr; hld; hld = hld->ai_next) {
+        result = srt_connect(mContext, reinterpret_cast<sockaddr*>(hld->ai_addr), hld->ai_addrlen);
+        if (result != SRT_ERROR) {
+            SRT_LOGGER(true, LOGG_ERROR, "Connected to SRT Server " << std::endl)
+            mClientConnected = true;
+            break;
+        }
+    }
+    freeaddrinfo(svr);
+    if (result == SRT_ERROR) {
+        srt_close(mContext);
+        SRT_LOGGER(true, LOGG_FATAL, "srt_connect failed " << std::endl);
+    }
+
+    mCurrentMode = Mode::client;
+    mClientActive = true;
+    mWorkerThread = std::thread(&SRTNet::clientWorker, this);
+
+    return true;
+}
+
+bool SRTNet::createClientSocket() {
     int result = 0;
     int32_t yes = 1;
     SRT_LOGGER(true, LOGG_NOTIFY, "SRT client startup");
@@ -361,31 +418,31 @@ bool SRTNet::startClient(const std::string& host,
         return false;
     }
 
-    result = srt_setsockflag(mContext, SRTO_LATENCY, &latency, sizeof(latency));
+    result = srt_setsockflag(mContext, SRTO_LATENCY, &mCallerLatency, sizeof(mCallerLatency));
     if (result == SRT_ERROR) {
         SRT_LOGGER(true, LOGG_FATAL, "srt_setsockflag SRTO_LATENCY: " << srt_getlasterror_str());
         return false;
     }
 
-    result = srt_setsockflag(mContext, SRTO_LOSSMAXTTL, &reorder, sizeof(reorder));
+    result = srt_setsockflag(mContext, SRTO_LOSSMAXTTL, &mCallerReorder, sizeof(mCallerReorder));
     if (result == SRT_ERROR) {
         SRT_LOGGER(true, LOGG_FATAL, "srt_setsockflag SRTO_LOSSMAXTTL: " << srt_getlasterror_str());
         return false;
     }
 
-    result = srt_setsockflag(mContext, SRTO_OHEADBW, &overhead, sizeof(overhead));
+    result = srt_setsockflag(mContext, SRTO_OHEADBW, &mCallerOverhead, sizeof(mCallerOverhead));
     if (result == SRT_ERROR) {
         SRT_LOGGER(true, LOGG_FATAL, "srt_setsockflag SRTO_OHEADBW: " << srt_getlasterror_str());
         return false;
     }
 
-    result = srt_setsockflag(mContext, SRTO_PAYLOADSIZE, &mtu, sizeof(mtu));
+    result = srt_setsockflag(mContext, SRTO_PAYLOADSIZE, &mCallerMtu, sizeof(mCallerMtu));
     if (result == SRT_ERROR) {
         SRT_LOGGER(true, LOGG_FATAL, "srt_setsockflag SRTO_PAYLOADSIZE: " << srt_getlasterror_str());
         return false;
     }
 
-    if (psk.length()) {
+    if (mCallerPsk.length()) {
         int32_t aes128 = 16;
         result = srt_setsockflag(mContext, SRTO_PBKEYLEN, &aes128, sizeof(aes128));
         if (result == SRT_ERROR) {
@@ -393,30 +450,37 @@ bool SRTNet::startClient(const std::string& host,
             return false;
         }
 
-        result = srt_setsockflag(mContext, SRTO_PASSPHRASE, psk.c_str(), psk.length());
+        result = srt_setsockflag(mContext, SRTO_PASSPHRASE, mCallerPsk.c_str(), mCallerPsk.length());
         if (result == SRT_ERROR) {
             SRT_LOGGER(true, LOGG_FATAL, "srt_setsockflag SRTO_PASSPHRASE: " << srt_getlasterror_str());
             return false;
         }
     }
 
-    result = srt_setsockflag(mContext, SRTO_PEERIDLETIMEO, &peerIdleTimeout, sizeof(peerIdleTimeout));
+    result = srt_setsockflag(mContext, SRTO_PEERIDLETIMEO, &mCallerPeerIdleTimeout, sizeof(mCallerPeerIdleTimeout));
     if (result == SRT_ERROR) {
         SRT_LOGGER(true, LOGG_FATAL, "srt_setsockflag : SRTO_PEERIDLETIMEO" << srt_getlasterror_str());
         return false;
     }
 
-    if (!localHost.empty() || localPort != 0) {
+    const int connection_timeout_ms = 1000;
+    result = srt_setsockopt(mContext, 0, SRTO_CONNTIMEO, &connection_timeout_ms, sizeof connection_timeout_ms);
+    if (result == SRT_ERROR) {
+        SRT_LOGGER(true, LOGG_FATAL, "srt_setsockopt: SRTO_CONNTIMEO" << srt_getlasterror_str());
+        return false;
+    }
+
+    if (!mCallerLocalHost.empty() || mCallerLocalPort != 0) {
         // Set local interface to bind to
 
-        if (localHost.empty()) {
+        if (mCallerLocalHost.empty()) {
             SRT_LOGGER(true, LOGG_FATAL,
                        "Local port was provided but local IP is not set, cannot bind to local address");
             srt_close(mContext);
             return false;
         }
 
-        SocketAddress localSocketAddress(localHost, localPort);
+        SocketAddress localSocketAddress(mCallerLocalHost, mCallerLocalPort);
 
         std::optional<sockaddr_in> localIPv4Address = localSocketAddress.getIPv4();
         if (localIPv4Address.has_value()) {
@@ -447,56 +511,65 @@ bool SRTNet::startClient(const std::string& host,
         }
     }
 
-    // Get all remote addresses for connection
-    struct addrinfo hints = {0};
-    struct addrinfo* svr;
-    struct addrinfo* hld;
-    hints.ai_socktype = SOCK_DGRAM;
-    hints.ai_protocol = IPPROTO_UDP;
-    hints.ai_family = AF_UNSPEC;
-    std::stringstream portAsString;
-    portAsString << port;
-    result = getaddrinfo(host.c_str(), portAsString.str().c_str(), &hints, &svr);
-    if (result) {
-        SRT_LOGGER(true, LOGG_FATAL,
-                   "Failed getting the IP target for > " << host << ":" << port << " Errno: " << result);
-        return false;
-    }
-
-    SRT_LOGGER(true, LOGG_NOTIFY, "SRT connect");
-    for (hld = svr; hld; hld = hld->ai_next) {
-        result = srt_connect(mContext, reinterpret_cast<sockaddr*>(hld->ai_addr), hld->ai_addrlen);
-        if (result != SRT_ERROR) {
-            SRT_LOGGER(true, LOGG_NOTIFY, "Connected to SRT Server " << std::endl)
-            break;
-        }
-    }
-    if (result == SRT_ERROR) {
-        srt_close(mContext);
-        freeaddrinfo(svr);
-        SRT_LOGGER(true, LOGG_FATAL, "srt_connect failed " << std::endl);
-        return false;
-    }
-    freeaddrinfo(svr);
-    mCurrentMode = Mode::client;
-    mClientActive = true;
-    mWorkerThread = std::thread(&SRTNet::clientWorker, this);
     return true;
 }
 
 void SRTNet::clientWorker() {
     while (mClientActive) {
+        if (!mClientConnected) {
+            // Get all remote addresses for connection
+            struct addrinfo hints = {0};
+            struct addrinfo* svr;
+            struct addrinfo* hld;
+            hints.ai_socktype = SOCK_DGRAM;
+            hints.ai_protocol = IPPROTO_UDP;
+            hints.ai_family = AF_UNSPEC;
+            std::stringstream portAsString;
+            portAsString << mCallerPort;
+            int result = getaddrinfo(mCallerHost.c_str(), portAsString.str().c_str(), &hints, &svr);
+            if (result) {
+                SRT_LOGGER(true, LOGG_FATAL,
+                        "Failed getting the IP target for > " << mCallerHost << ":" << mCallerPort << " Errno: " << result);
+                break;
+            }
+
+            //TODO SRT_LOGGER(true, LOGG_ERROR, "SRT connect");
+            for (hld = svr; hld; hld = hld->ai_next) {
+                result = srt_connect(mContext, reinterpret_cast<sockaddr*>(hld->ai_addr), hld->ai_addrlen);
+                if (result != SRT_ERROR) {
+                    SRT_LOGGER(true, LOGG_ERROR, "Connected to SRT Server " << std::endl)
+                    mClientConnected = true;
+                    // Break for-loop on first successfull connect call
+                    break;
+                }
+            }
+            freeaddrinfo(svr);
+            if (result == SRT_ERROR) {
+                // Failed to connect caller/client, try again, the connect call waited some time before
+                // giving up
+                //TODO SRT_LOGGER(true, LOGG_FATAL, "srt_connect failed " << std::endl);
+                continue;
+            }
+        }
+
         uint8_t msg[2048];
         SRT_MSGCTRL thisMSGCTRL = srt_msgctrl_default;
         int result = srt_recvmsg2(mContext, reinterpret_cast<char*>(msg), sizeof(msg), &thisMSGCTRL);
         if (result == SRT_ERROR) {
+            mClientConnected = false;
+
+            SRTSOCKET context = mContext;
             if (mClientActive) {
                 SRT_LOGGER(true, LOGG_ERROR, "srt_recvmsg error: " << srt_getlasterror_str());
+                srt_close(mContext);
+                if (!createClientSocket()) {
+                    SRT_LOGGER(true, LOGG_ERROR, "Failed to re-create caller socket");
+                    break;
+                }
             }
             if (clientDisconnected) {
-                clientDisconnected(mClientContext, mContext);
+                clientDisconnected(mClientContext, context);
             }
-            break;
         } else if (result > 0 && receivedData) {
             auto data = std::make_unique<std::vector<uint8_t>>(msg, msg + result);
             receivedData(data, thisMSGCTRL, mClientContext, mContext);
@@ -505,6 +578,11 @@ void SRTNet::clientWorker() {
         }
     }
     mClientActive = false;
+/*    mCurrentMode = Mode::unknown;
+    mClientContext = nullptr;
+    srt_close(mContext);
+    mContext = 0;
+    */
 }
 
 std::pair<SRTSOCKET, std::shared_ptr<SRTNet::NetworkConnection>> SRTNet::getConnectedServer() {
@@ -512,6 +590,10 @@ std::pair<SRTSOCKET, std::shared_ptr<SRTNet::NetworkConnection>> SRTNet::getConn
         return {mContext, mClientContext};
     }
     return {0, nullptr};
+}
+
+bool SRTNet::isClientConnected() const {
+    return mClientConnected;
 }
 
 SRTSOCKET SRTNet::getBoundSocket() const {
@@ -538,7 +620,7 @@ void SRTNet::setLogHandler(SRT_LOG_HANDLER_FN* handler, int loglevel) {
 bool SRTNet::sendData(const uint8_t* data, size_t len, SRT_MSGCTRL* msgCtrl, SRTSOCKET targetSystem) {
     int result;
 
-    if (mCurrentMode == Mode::client && mContext && mClientActive) {
+    if (mCurrentMode == Mode::client && mContext && mClientActive && mClientConnected) {
         result = srt_sendmsg2(mContext, reinterpret_cast<const char*>(data), len, msgCtrl);
     } else if (mCurrentMode == Mode::server && targetSystem && mServerActive) {
         result = srt_sendmsg2(targetSystem, reinterpret_cast<const char*>(data), len, msgCtrl);
@@ -604,6 +686,10 @@ bool SRTNet::stop() {
 bool SRTNet::getStatistics(SRT_TRACEBSTATS* currentStats, int clear, int instantaneous, SRTSOCKET targetSystem) {
     std::lock_guard<std::mutex> lock(mNetMtx);
     if (mCurrentMode == Mode::client && mClientActive && mContext) {
+        if (!mClientConnected) {
+            memset(currentStats, 0, sizeof(SRT_TRACEBSTATS));
+            return true;
+        }
         int result = srt_bistats(mContext, currentStats, clear, instantaneous);
         if (result == SRT_ERROR) {
             SRT_LOGGER(true, LOGG_ERROR, "srt_bistats failed: " << srt_getlasterror_str());

--- a/SRTNet.h
+++ b/SRTNet.h
@@ -144,7 +144,7 @@ public:
      * @param peerIdleTimeout Optional Connection considered broken if no packet received before this timeout.
      * Defaults to 5 seconds.
      * @param psk Optional Pre Shared Key (AES-128)
-     * @return true if client was able to connect to the server
+     * @return true if configuration was ok and remote IP port could be resolved, false otherwise
      */
     bool startClient(const std::string& host,
                      uint16_t port,
@@ -210,6 +210,13 @@ public:
      *
      */
     std::pair<SRTSOCKET, std::shared_ptr<NetworkConnection>> getConnectedServer();
+
+    /**
+     * 
+     * @brief Check if client is connected to remote end
+     * @returns True is client is connected to the the remote end, false otherwise
+    */
+    bool isClientConnected() const;
 
     /**
      *
@@ -289,6 +296,8 @@ private:
 
     void closeAllClientSockets();
 
+    bool createClientSocket();
+
     SRT_LOG_HANDLER_FN* logHandler = defaultLogHandler;
 
     // Server active? true == yes
@@ -307,4 +316,16 @@ private:
     std::mutex mClientListMtx;
     std::shared_ptr<NetworkConnection> mClientContext = nullptr;
     std::shared_ptr<NetworkConnection> mConnectionContext = nullptr;
+    std::atomic<bool> mClientConnected = false;
+    std::string mCallerHost;
+    uint16_t mCallerPort;
+
+    std::string mCallerLocalHost;
+    uint16_t mCallerLocalPort;
+    int mCallerReorder;
+    int32_t mCallerLatency;
+    int mCallerOverhead;
+    int mCallerMtu;
+    int32_t mCallerPeerIdleTimeout;
+    std::string mCallerPsk;
 };

--- a/SRTNet.h
+++ b/SRTNet.h
@@ -130,7 +130,8 @@ public:
 
     /**
      *
-     * Starts an SRT Client with a specified local address to bind to
+     * Starts an SRT Client with a specified local address to bind to and connects to the server. If the server is
+     * currently not listening for connections, the client will keep on trying to re-connect.
      *
      * @param host Remote host IP or hostname to connect to
      * @param port Remote host port to connect to
@@ -144,7 +145,8 @@ public:
      * @param peerIdleTimeout Optional Connection considered broken if no packet received before this timeout.
      * Defaults to 5 seconds.
      * @param psk Optional Pre Shared Key (AES-128)
-     * @return true if configuration was ok and remote IP port could be resolved, false otherwise
+     * @return true if configuration was accepted and remote IP port could be resolved, false otherwise. It will also
+     * return false in case the connection can be made but the provided PSK doesn't match the PSK on the server.
      */
     bool startClient(const std::string& host,
                      uint16_t port,
@@ -328,4 +330,6 @@ private:
     int mCallerMtu;
     int32_t mCallerPeerIdleTimeout;
     std::string mCallerPsk;
+
+    const std::chrono::milliseconds kConnectionTimeout{1000};
 };

--- a/test/TestSrt.cpp
+++ b/test/TestSrt.cpp
@@ -214,11 +214,8 @@ TEST(TestSrt, TestPsk) {
     server.clientConnected = [&](struct sockaddr& sin, SRTSOCKET newSocket,
                                  std::shared_ptr<SRTNet::NetworkConnection>& ctx) { return ctx; };
     ASSERT_TRUE(server.startServer("127.0.0.1", 8009, 16, 1000, 100, SRT_LIVE_MAX_PLSIZE, 5000, kValidPsk, false, ctx));
-    EXPECT_TRUE(client.startClient("127.0.0.1", 8009, 16, 1000, 100, ctx, SRT_LIVE_MAX_PLSIZE, 5000, kInvalidPsk))
-        << "Expected to be able to start client, but not connect when using incorrect PSK";
-    EXPECT_FALSE(client.isClientConnected())
+    EXPECT_FALSE(client.startClient("127.0.0.1", 8009, 16, 1000, 100, ctx, SRT_LIVE_MAX_PLSIZE, 5000, kInvalidPsk))
         << "Expect to fail when using incorrect PSK";
-    EXPECT_TRUE(client.stop());
 
     ASSERT_TRUE(server.stop());
     ASSERT_TRUE(server.startServer("127.0.0.1", 8009, 16, 1000, 100, SRT_LIVE_MAX_PLSIZE, 5000, kValidPsk, false, ctx));

--- a/test/TestSrt.cpp
+++ b/test/TestSrt.cpp
@@ -112,8 +112,11 @@ TEST(TestSrt, StartStop) {
         << "Expect to fail without providing clientConnected callback";
     auto clientCtx = std::make_shared<SRTNet::NetworkConnection>();
     clientCtx->mObject = 42;
-    EXPECT_FALSE(client.startClient("127.0.0.1", 8009, 16, 1000, 100, clientCtx, SRT_LIVE_MAX_PLSIZE, 5000, kValidPsk))
+    EXPECT_TRUE(client.startClient("127.0.0.1", 8009, 16, 1000, 100, clientCtx, SRT_LIVE_MAX_PLSIZE, 5000, kValidPsk))
+        << "Expect client to start, but not be able to connect with no server started";
+    EXPECT_FALSE(client.isClientConnected())
         << "Expect to fail with no server started";
+    EXPECT_TRUE(client.stop());
 
     std::condition_variable connectedCondition;
     std::mutex connectedMutex;
@@ -135,6 +138,7 @@ TEST(TestSrt, StartStop) {
     ASSERT_TRUE(
         server.startServer("127.0.0.1", 8009, 16, 1000, 100, SRT_LIVE_MAX_PLSIZE, 5000, kValidPsk, false, serverCtx));
     ASSERT_TRUE(client.startClient("127.0.0.1", 8009, 16, 1000, 100, clientCtx, SRT_LIVE_MAX_PLSIZE, 5000, kValidPsk));
+    ASSERT_TRUE(client.isClientConnected());
 
     // check for client connecting
     {
@@ -184,6 +188,7 @@ TEST(TestSrt, StartStop) {
     connected = false;
     SRTNet client2;
     ASSERT_TRUE(client2.startClient("127.0.0.1", 8009, 16, 1000, 100, clientCtx, SRT_LIVE_MAX_PLSIZE, 5000, kValidPsk));
+    ASSERT_TRUE(client2.isClientConnected());
     // check for client connecting
     {
         std::unique_lock<std::mutex> lock(connectedMutex);
@@ -209,17 +214,22 @@ TEST(TestSrt, TestPsk) {
     server.clientConnected = [&](struct sockaddr& sin, SRTSOCKET newSocket,
                                  std::shared_ptr<SRTNet::NetworkConnection>& ctx) { return ctx; };
     ASSERT_TRUE(server.startServer("127.0.0.1", 8009, 16, 1000, 100, SRT_LIVE_MAX_PLSIZE, 5000, kValidPsk, false, ctx));
-    EXPECT_FALSE(client.startClient("127.0.0.1", 8009, 16, 1000, 100, ctx, SRT_LIVE_MAX_PLSIZE, 5000, kInvalidPsk))
+    EXPECT_TRUE(client.startClient("127.0.0.1", 8009, 16, 1000, 100, ctx, SRT_LIVE_MAX_PLSIZE, 5000, kInvalidPsk))
+        << "Expected to be able to start client, but not connect when using incorrect PSK";
+    EXPECT_FALSE(client.isClientConnected())
         << "Expect to fail when using incorrect PSK";
+    EXPECT_TRUE(client.stop());
 
     ASSERT_TRUE(server.stop());
     ASSERT_TRUE(server.startServer("127.0.0.1", 8009, 16, 1000, 100, SRT_LIVE_MAX_PLSIZE, 5000, kValidPsk, false, ctx));
     EXPECT_TRUE(client.startClient("127.0.0.1", 8009, 16, 1000, 100, ctx, SRT_LIVE_MAX_PLSIZE, 5000, kValidPsk));
+    ASSERT_TRUE(client.isClientConnected());
 
     ASSERT_TRUE(server.stop());
     ASSERT_TRUE(client.stop());
     ASSERT_TRUE(server.startServer("127.0.0.1", 8009, 16, 1000, 100, SRT_LIVE_MAX_PLSIZE, 5000, "", false, ctx));
     EXPECT_TRUE(client.startClient("127.0.0.1", 8009, 16, 1000, 100, ctx, SRT_LIVE_MAX_PLSIZE));
+    ASSERT_TRUE(client.isClientConnected());
 }
 
 TEST_F(TestSRTFixture, SendReceive) {
@@ -227,6 +237,7 @@ TEST_F(TestSRTFixture, SendReceive) {
     ASSERT_TRUE(
         mServer.startServer("127.0.0.1", 8009, 16, 1000, 100, SRT_LIVE_MAX_PLSIZE, 5000, kValidPsk, false, mServerCtx));
     ASSERT_TRUE(mClient.startClient("127.0.0.1", 8009, 16, 1000, 100, mClientCtx, SRT_LIVE_MAX_PLSIZE, 5000, kValidPsk));
+    ASSERT_TRUE(mClient.isClientConnected());
 
     std::vector<uint8_t> sendBuffer(1000);
     std::condition_variable serverCondition;
@@ -299,6 +310,7 @@ TEST_F(TestSRTFixture, SendReceiveIPv6) {
     // start server and client
     ASSERT_TRUE(mServer.startServer("::", 8020, 16, 1000, 100, SRT_LIVE_MAX_PLSIZE, 5000, "", true, mServerCtx));
     ASSERT_TRUE(mClient.startClient("::1", 8020, 16, 1000, 100, mClientCtx, SRT_LIVE_MAX_PLSIZE, 5000, ""));
+    ASSERT_TRUE(mClient.isClientConnected());
 
     std::vector<uint8_t> sendBuffer(1000);
     std::condition_variable serverCondition;
@@ -372,6 +384,7 @@ TEST_F(TestSRTFixture, LargeMessage) {
     ASSERT_TRUE(
         mServer.startServer("127.0.0.1", 8009, 16, 1000, 100, SRT_LIVE_MAX_PLSIZE, 5000, kValidPsk, false, mServerCtx));
     ASSERT_TRUE(mClient.startClient("127.0.0.1", 8009, 16, 1000, 100, mClientCtx, SRT_LIVE_MAX_PLSIZE, 5000, kValidPsk));
+    ASSERT_TRUE(mClient.isClientConnected());
 
     std::vector<uint8_t> sendBuffer(kMaxMessageSize + 1);
     std::fill(sendBuffer.begin(), sendBuffer.end(), 1);
@@ -385,7 +398,7 @@ TEST_F(TestSRTFixture, DISABLED_RejectConnection) {
     EXPECT_TRUE(mServer.startServer("127.0.0.1", 8009, 16, 1000, 100, SRT_LIVE_MAX_PLSIZE, 5000, kValidPsk, false, ctx));
     EXPECT_FALSE(mClient.startClient("127.0.0.1", 8009, 16, 1000, 100, ctx, SRT_LIVE_MAX_PLSIZE, 5000, kValidPsk))
         << "Expected client connection rejected";
-
+    
     ASSERT_TRUE(waitForClientToConnect(std::chrono::seconds(2)));
 
     auto numberOfClients = 0;
@@ -429,6 +442,7 @@ TEST_F(TestSRTFixture, SingleSender) {
     ASSERT_TRUE(
         mServer.startServer("127.0.0.1", 8009, 16, 1000, 100, SRT_LIVE_MAX_PLSIZE, 5000, kValidPsk, true, mServerCtx));
     ASSERT_TRUE(mClient.startClient("127.0.0.1", 8009, 16, 1000, 100, mClientCtx, SRT_LIVE_MAX_PLSIZE, 5000, kValidPsk));
+    ASSERT_TRUE(mClient.isClientConnected());
 
     ASSERT_TRUE(waitForClientToConnect(std::chrono::seconds(2)));
 
@@ -452,8 +466,10 @@ TEST_F(TestSRTFixture, SingleSender) {
     // start a new client, should fail since we only accept one single client
     mConnected = false;
     SRTNet client2;
-    ASSERT_FALSE(
+    ASSERT_TRUE(
         client2.startClient("127.0.0.1", 8009, 16, 1000, 100, mClientCtx, SRT_LIVE_MAX_PLSIZE, 5000, kValidPsk));
+    EXPECT_FALSE(client2.isClientConnected())
+        << "Expect to not be able to connect a second client when server just accepts one client";
 
     mServer.getActiveClients([&](std::map<SRTSOCKET, std::shared_ptr<SRTNet::NetworkConnection>>& activeClients) {
         numberOfClients = activeClients.size();
@@ -473,6 +489,8 @@ TEST_F(TestSRTFixture, BindAddressForCaller) {
         mServer.startServer("127.0.0.1", 8010, 16, 1000, 100, SRT_LIVE_MAX_PLSIZE, 5000, kValidPsk, false, mServerCtx));
     ASSERT_TRUE(mClient.startClient("127.0.0.1", 8010, "0.0.0.0", 8011, 16, 1000, 100, mClientCtx, SRT_LIVE_MAX_PLSIZE,
                                    5000, kValidPsk));
+    ASSERT_TRUE(mClient.isClientConnected());
+
 
     ASSERT_TRUE(waitForClientToConnect(std::chrono::seconds(2)));
 
@@ -562,6 +580,7 @@ TEST_F(TestSRTFixture, FailToBindWhenLocalIPIsCorrupt) {
 TEST_F(TestSRTFixture, FailToConnectWhenRemoteHostnameIsCorrupt) {
     uint16_t kPort = 8023;
     std::string kIllFormattedIP = "thi$i$not_a(host)name.com";
-    ASSERT_FALSE(mClient.startClient(kIllFormattedIP, kPort, 16, 1000, 100, mClientCtx,
+    EXPECT_FALSE(mClient.startClient(kIllFormattedIP, kPort, 16, 1000, 100, mClientCtx,
                                      SRT_LIVE_MAX_PLSIZE, 5000, kValidPsk));
+    ASSERT_FALSE(mClient.isClientConnected());                                     
 }


### PR DESCRIPTION
startClient now returns true even if the connection to the remote end fails. The worker thread of the client will then try to (re-)connect until a successfull connection is made.

To check if the client actually is connected, a new function: isClientConnected was added.