### PR TITLE
STAR-964: Add new parameter to startClient functions

### DIFF
--- a/SRTNet.cpp
+++ b/SRTNet.cpp
@@ -292,9 +292,10 @@ bool SRTNet::startClient(const std::string& host,
                          int overhead,
                          std::shared_ptr<NetworkConnection>& ctx,
                          int mtu,
+                         bool failOnConnectionError,
                          int32_t peerIdleTimeout,
                          const std::string& psk) {
-    return startClient(host, port, "", 0, reorder, latency, overhead, ctx, mtu, peerIdleTimeout, psk);
+    return startClient(host, port, "", 0, reorder, latency, overhead, ctx, mtu, failOnConnectionError, peerIdleTimeout, psk);
 }
 
 // Host can provide a IP or name meaning any IPv4 or IPv6 address or name type www.google.com
@@ -308,6 +309,7 @@ bool SRTNet::startClient(const std::string& host,
                          int overhead,
                          std::shared_ptr<NetworkConnection>& ctx,
                          int mtu,
+                         bool failOnConnectionError,
                          int32_t peerIdleTimeout,
                          const std::string& psk) {
     std::lock_guard<std::mutex> lock(mNetMtx);
@@ -370,7 +372,8 @@ bool SRTNet::startClient(const std::string& host,
     if (result == SRT_ERROR) {
         SRT_LOGGER(true, LOGG_FATAL, "srt_connect failed: " << srt_getlasterror_str() << std::endl);
         int rejectReason = srt_getrejectreason(mContext);
-        if (rejectReason == SRT_REJECT_REASON::SRT_REJ_BADSECRET ||
+        if (failOnConnectionError ||
+            rejectReason == SRT_REJECT_REASON::SRT_REJ_BADSECRET ||
             rejectReason == SRT_REJECT_REASON::SRT_REJ_UNSECURE) {
             srt_close(mContext);
             return false;

--- a/SRTNet.h
+++ b/SRTNet.h
@@ -104,8 +104,9 @@ public:
 
     /**
      *
-     * Starts an SRT Client and connects to the server. If the server is currently not listening for connections, the
-     * client will keep on trying to re-connect.
+     * Starts an SRT Client and connects to the server. If the server is currently not listening for connections, or the
+     * client can't reach the server over the network, the client may keep on trying to re-connect or fail to start
+     * depending on the value or \p failOnConnectionError.
      *
      * @param host Remote host IP or hostname
      * @param port Remote host Port
@@ -114,6 +115,10 @@ public:
      * @param overhead % extra of the BW that will be allowed for re-transmission packets
      * @param ctx the context used in the receivedData and receivedDataNoCopy callback
      * @param mtu sets the MTU
+     * @param failOnConnectionError if set to true and the initial connection attempt to the server fails this function
+     * will return false, if set to false the client will start an internal thread that will keep on trying to connect
+     * to the server until stop() is called. If the initial connection attempt is successful, the client will always
+     * try to re-connect to the server in case the client gets disconnected.
      * @param peerIdleTimeout Optional Connection considered broken if no packet received before this timeout.
      * Defaults to 5 seconds.
      * @param psk Optional Pre Shared Key (AES-128)
@@ -127,13 +132,15 @@ public:
                      int overhead,
                      std::shared_ptr<NetworkConnection>& ctx,
                      int mtu,
+                     bool failOnConnectionError,
                      int32_t peerIdleTimeout = 5000,
                      const std::string& psk = "");
 
     /**
      *
      * Starts an SRT Client with a specified local address to bind to and connects to the server. If the server is
-     * currently not listening for connections, the client will keep on trying to re-connect.
+     * currently not listening for connections, or the client can't reach the server over the network, the client may
+     * keep on trying to re-connect or fail to start depending on the value or \p failOnConnectionError.
      *
      * @param host Remote host IP or hostname to connect to
      * @param port Remote host port to connect to
@@ -144,6 +151,10 @@ public:
      * @param overhead % extra of the BW that will be allowed for re-transmission packets
      * @param ctx the context used in the receivedData and receivedDataNoCopy callback
      * @param mtu sets the MTU
+     * @param failOnConnectionError if set to true and the initial connection attempt to the server fails this function
+     * will return false, if set to false the client will start an internal thread that will keep on trying to connect
+     * to the server until stop() is called. If the initial connection attempt is successful, the client will always
+     * try to re-connect to the server in case the client gets disconnected.
      * @param peerIdleTimeout Optional Connection considered broken if no packet received before this timeout.
      * Defaults to 5 seconds.
      * @param psk Optional Pre Shared Key (AES-128)
@@ -159,6 +170,7 @@ public:
                      int overhead,
                      std::shared_ptr<NetworkConnection>& ctx,
                      int mtu,
+                     bool failOnConnectionError,
                      int32_t peerIdleTimeout = 5000,
                      const std::string& psk = "");
 

--- a/main.cpp
+++ b/main.cpp
@@ -193,7 +193,7 @@ int main(int argc, const char *argv[]) {
 
     gSRTNetClient1.receivedData = std::bind(&handleDataClient, std::placeholders::_1, std::placeholders::_2,
                                             std::placeholders::_3, std::placeholders::_4);
-    if (!gSRTNetClient1.startClient("127.0.0.1", 8000, 16, 1000, 100, lClient1Connection, 1456, 5000,
+    if (!gSRTNetClient1.startClient("127.0.0.1", 8000, 16, 1000, 100, lClient1Connection, 1456, true, 5000,
                                     "Th1$_is_4_0pt10N4L_P$k")) {
         std::cout << "SRT client1 failed starting." << std::endl;
         return EXIT_FAILURE;
@@ -205,7 +205,7 @@ int main(int argc, const char *argv[]) {
     lClient2Connection->mObject = std::move(lpMyClass2);
     gSRTNetClient2.receivedData = std::bind(&handleDataClient, std::placeholders::_1, std::placeholders::_2,
                                             std::placeholders::_3, std::placeholders::_4);
-    if (!gSRTNetClient2.startClient("127.0.0.1", 8000, 16, 1000, 100, lClient2Connection, 1456, 5000,
+    if (!gSRTNetClient2.startClient("127.0.0.1", 8000, 16, 1000, 100, lClient2Connection, 1456, true, 5000,
                                     "Th1$_is_4_0pt10N4L_P$k")) {
         std::cout << "SRT client2 failed starting." << std::endl;
         return EXIT_FAILURE;


### PR DESCRIPTION
The new parameter failOnConnectionError controls the behaviour of the startClient functions. If it is set to true and the initial connection attempt to the server, which is done in startClient, fails, the startClient call returns true. If it is set to false the clientStart call returns true and the worker thread is started which will now start to try to connect to the server until stop() is called.