### PR TITLE
STAR-1275: Read the peers SRT version and the negotiated latency from the socket

### DIFF
--- a/test/TestSrt.cpp
+++ b/test/TestSrt.cpp
@@ -79,7 +79,8 @@ public:
 
         // notice when client connects to server
         mServer.clientConnected = [&](struct sockaddr& sin, SRTSOCKET newSocket,
-                                      std::shared_ptr<SRTNet::NetworkConnection>& ctx) {
+                                      std::shared_ptr<SRTNet::NetworkConnection>& ctx,
+                                      const SRTNet::ConnectionInformation&) {
             {
                 std::lock_guard<std::mutex> lock(mConnectedMutex);
                 mConnected = true;
@@ -150,7 +151,8 @@ TEST(TestSrt, StartStop) {
 
     // notice when client connects to server
     server.clientConnected = [&](struct sockaddr& sin, SRTSOCKET newSocket,
-                                 std::shared_ptr<SRTNet::NetworkConnection>& ctx) {
+                                 std::shared_ptr<SRTNet::NetworkConnection>& ctx,
+                                 const SRTNet::ConnectionInformation&) {
         {
             std::lock_guard<std::mutex> lock(connectedMutex);
             connected = true;
@@ -239,7 +241,8 @@ TEST(TestSrt, TestPsk) {
 
     auto ctx = std::make_shared<SRTNet::NetworkConnection>();
     server.clientConnected = [&](struct sockaddr& sin, SRTSOCKET newSocket,
-                                 std::shared_ptr<SRTNet::NetworkConnection>& ctx) { return ctx; };
+                                 std::shared_ptr<SRTNet::NetworkConnection>& ctx,
+                                 const SRTNet::ConnectionInformation&) { return ctx; };
     ASSERT_TRUE(server.startServer("127.0.0.1", 8009, 16, 1000, 100, SRT_LIVE_MAX_PLSIZE, 5000, kValidPsk, false, ctx));
     EXPECT_FALSE(client.startClient("127.0.0.1", 8009, 16, 1000, 100, ctx, SRT_LIVE_MAX_PLSIZE, false, 5000, kInvalidPsk))
         << "Expect to fail when using incorrect PSK";


### PR DESCRIPTION
Suggestion of a way to pass SRT library version from client and the negotiated latency back to the user of SRTNet.

We can then extend our logs from for example:
`[2024-05-07 16:19:00.737] [LD_Pipeline] [acl-renderingen-771773] [info]  program 1: Client connected to server: 127.0.0.1:4567`
to:
`[2024-05-07 16:19:00.737] [LD_Pipeline] [acl-renderingen-771773] [info]  program 1: Client connected to server: 127.0.0.1:4567, SRT version: 1.4.4, latency: 3098`