### PR TITLE
STAR-1582 Fix deadlock on client stop

### DIFF
--- a/SRTNet.cpp
+++ b/SRTNet.cpp
@@ -899,10 +899,6 @@ bool SRTNet::stop() {
     } else if (mCurrentMode == Mode::client) {
         mClientActive = false;
 
-        if (mWorkerThread.joinable()) {
-            mWorkerThread.join();
-        }
-
         std::lock_guard<std::mutex> lock(mNetMtx);
         if (mContext != SRT_INVALID_SOCK) {
             int result = srt_close(mContext);
@@ -912,6 +908,11 @@ bool SRTNet::stop() {
                 return false;
             }
         }
+
+        if (mWorkerThread.joinable()) {
+            mWorkerThread.join();
+        }
+
         mClientConnected = false;
 
         SRT_LOGGER(true, LOGG_NOTIFY, "Client stopped");


### PR DESCRIPTION
Fix deadlock when shutting down a client, which would get stuck indefinitely 1 out of 5 times in the main thread when calling stop. The deadlock was caused by the main thread getting stuck while waiting for the client thread to join. At the same time, the client worker thread was stuck waiting for recv to return a value. In case no data was sent on the network and the remote side did not disconnect, the main thread would be stuck indefinitely. This commit solves the issue by first closing the SRT socket before trying to join the thread, instead of after, as earlier. This makes the recv call return an error and exit the thread loop.